### PR TITLE
Add fmt dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   "A library for adding syntax highlighting to OCaml-related code and outputing to HTML")
  (depends
    ocaml
+  (fmt (>= 0.8.7))
   (mdx (and (>= 2.4.1) :with-test))
   (cmarkit (and (>= 0.3.0) :with-test))
   (re (and (>= 1.14.0) :with-test))

--- a/hilite.opam
+++ b/hilite.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/patricoferris/hilite/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml"
+  "fmt" {>= "0.8.7"}
   "mdx" {>= "2.4.1" & with-test}
   "cmarkit" {>= "0.3.0" & with-test}
   "re" {>= "1.14.0" & with-test}


### PR DESCRIPTION
OCaml.org would not build with dune package management without the fmt dependency  because the optional hilite.markdown library uses `Fmt` APIs. Without declaring that dependency Dune package management skips installing `hilite.markdown`.